### PR TITLE
Fix damages in units

### DIFF
--- a/app/views/units/_description.html.erb
+++ b/app/views/units/_description.html.erb
@@ -106,7 +106,7 @@
     <strong><%= t('unit_damages') %></strong>:
     <ul>
       <% @unit.unit_damages.each do |damage| %>
-        <li><%= show_item(t(damage.code)) %></li>
+        <li><%= damage.code %></li>
       <% end %>
     </ul>
   </p>


### PR DESCRIPTION
Fix damages in units.

Damages try to translate damage.code but translation is missing. The problem is that archimista saves the value (already translated) of damage instead of the code. This is a bug in archimista that should be fix in the future.

Note in almost all cases archimista uses values instead of codes...
